### PR TITLE
Revert "Hotfix/resolve geocoding"

### DIFF
--- a/lib/postal-address/postal-address.controllers.js
+++ b/lib/postal-address/postal-address.controllers.js
@@ -82,7 +82,7 @@ module.exports = (models) => {
     if (process.env.hasOwnProperty('GEO_BOUNDING')) {
       api.searchParams.set('bounds', process.env.GEO_BOUNDING);
     }
-    console.log('api request', api);
+
     return new Promise((resolve, reject) => {
 
       https.get(api, res => {

--- a/lib/property/property.controllers.js
+++ b/lib/property/property.controllers.js
@@ -75,7 +75,6 @@ module.exports = (models) => {
 
       // take information in, process it
       var geocodes = await postalAddressLib.addressGeocode(request.payload.address);
-      console.log('geocodes', geocodes);
       if (!geocodes.results || geocodes.results.length === 0) {
         throw Boom.badData('No results for that address');
       }
@@ -259,7 +258,6 @@ module.exports = (models) => {
 
         // Geocode address
         var geocodes = await postalAddressLib.addressGeocode(request.payload.address);
-        console.log('geocodes', geocodes);
         if (!geocodes.results || geocodes.results.length === 0) {
           throw Boom.badData('No results for that address');
         }


### PR DESCRIPTION
Reverts GazeDev/housingdb_api#53

Geocoding issue was figured out. The GEO_BOUNDING variable was set wrong on Heroku. No longer need these logs